### PR TITLE
Support kafka 2.8.2 and fix snyk issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ import com.typesafe.sbt.packager.docker.{Cmd, DockerPermissionStrategy, ExecCmd}
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport._
 import com.typesafe.sbt.packager.docker.DockerApiVersion
 import com.typesafe.sbt.packager.docker.DockerPlugin.UnixSeparatorChar
-import sbt.IO
 
 import java.time.format.DateTimeFormatter
 import java.time.Instant
@@ -47,6 +46,9 @@ lazy val kafkaLagExporter =
         ScalaRedis,
         Logback,
         IAMAuthLib,
+        JacksonDataFormat,
+        SnakeYaml,
+        OkHttp,
         ScalaTest,
         AkkaTypedTestKit,
         MockitoScala,

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,46 +12,65 @@ services:
     image: wurstmeister/zookeeper:3.4.6
     ports:
       - "2181:2181"
+
   kafka:
-    image: wurstmeister/kafka:2.12-2.2.0
+    image: 246946804217.dkr.ecr.us-west-2.amazonaws.com/dh-mirror/confluentinc/cp-kafka:6.2.7
+    depends_on:
+      - zookeeper
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--zookeeper", "zookeeper:2181", "--create", "--topic", "healthcheck", "--partitions", "1", "--replication-factor", "1", "--if-not-exists"]
+      interval: 2s
+      timeout: 10s
+      retries: 5
+#    image: wurstmeister/kafka:2.12-2.2.0
     ports:
-      - "9094:9094"
-      - "1099:1099"
+      - "9092:9092"
+      - "1099:1098"
     environment:
-      HOSTNAME_COMMAND: "docker info | grep ^Name: | cut -d' ' -f 2"
-      PORT_COMMAND: "docker port `hostname` 9094 | cut -d: -f 2"
-      KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://_{HOSTNAME_COMMAND}:_{PORT_COMMAND}
-      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_JMX_OPTS: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.rmi.port=1099"
-      JMX_PORT: 1099
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9093,OUTSIDE://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_LOG4J_ROOT_LOGLEVEL: WARN
+      KAFKA_JMX_OPTS: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.rmi.port=1098"
+      JMX_PORT: 1098
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   kafka-producer-perf-test:
+    depends_on:
+      - kafka
     image: wurstmeister/kafka:2.12-2.2.0
     command: >
       bash -c "until kafka-topics.sh --zookeeper zookeeper:2181 --create --topic replicated-topic --partitions 3 --replication-factor 1 --if-not-exists; do echo \"Waiting for Kafka to be ready..\"; done
-      && kafka-producer-perf-test.sh --topic replicated-topic --num-records 10000000 --record-size 10 --throughput 1000 --producer-props bootstrap.servers=kafka:9092"
+      && kafka-producer-perf-test.sh --topic replicated-topic --num-records 10000000 --record-size 10 --throughput 1000 --producer-props bootstrap.servers=kafka:9093"
   # each kafka-consumer-test has its own consumer.id so it can be differentiated by consumer group information easily.
   consumer-group1-consumer1:
+    depends_on:
+      - kafka
     image: wurstmeister/kafka:2.12-2.2.0
     command: >
       bash -c "until kafka-topics.sh --zookeeper zookeeper:2181 --create --topic replicated-topic --partitions 3 --replication-factor 1 --if-not-exists; do echo \"Waiting for Kafka to be ready..\"; done
-      && kafka-console-consumer.sh --consumer-property group.id=test-consumer-group --consumer-property client.id=test-client-id-1 --consumer-property enable.auto.commit=true --topic replicated-topic --bootstrap-server kafka:9092 > /dev/null"
+      && kafka-console-consumer.sh --consumer-property group.id=test-consumer-group --consumer-property client.id=test-client-id-1 --consumer-property enable.auto.commit=true --topic replicated-topic --bootstrap-server kafka:9093 > /dev/null"
   consumer-group1-consumer2:
+    depends_on:
+      - kafka
     image: wurstmeister/kafka:2.12-2.2.0
     command: >
       bash -c "until kafka-topics.sh --zookeeper zookeeper:2181 --create --topic replicated-topic --partitions 3 --replication-factor 1 --if-not-exists; do echo \"Waiting for Kafka to be ready..\"; done
-      && kafka-console-consumer.sh --consumer-property group.id=test-consumer-group --consumer-property client.id=test-client-id-2 --consumer-property enable.auto.commit=true --topic replicated-topic --bootstrap-server kafka:9092 > /dev/null"
+      && kafka-console-consumer.sh --consumer-property group.id=test-consumer-group --consumer-property client.id=test-client-id-2 --consumer-property enable.auto.commit=true --topic replicated-topic --bootstrap-server kafka:9093 > /dev/null"
   consumer-group1-consumer3:
+    depends_on:
+      - kafka
     image: wurstmeister/kafka:2.12-2.2.0
     command: >
       bash -c "until kafka-topics.sh --zookeeper zookeeper:2181 --create --topic replicated-topic --partitions 3 --replication-factor 1 --if-not-exists; do echo \"Waiting for Kafka to be ready..\"; done
-      && kafka-console-consumer.sh --consumer-property group.id=test-consumer-group --consumer-property client.id=test-client-id-3 --consumer-property enable.auto.commit=true --topic replicated-topic --bootstrap-server kafka:9092 > /dev/null"
+      && kafka-console-consumer.sh --consumer-property group.id=test-consumer-group --consumer-property client.id=test-client-id-3 --consumer-property enable.auto.commit=true --topic replicated-topic --bootstrap-server kafka:9093 > /dev/null"
   consumer-group2-consumer1:
+    depends_on:
+      - kafka
     image: wurstmeister/kafka:2.12-2.2.0
     command: >
       bash -c "until kafka-topics.sh --zookeeper zookeeper:2181 --create --topic replicated-topic --partitions 3 --replication-factor 1 --if-not-exists; do echo \"Waiting for Kafka to be ready..\"; done
-      && kafka-console-consumer.sh --consumer-property group.id=test-consumer-group-two --consumer-property client.id=test-client-two-id-1 --consumer-property enable.auto.commit=true --topic replicated-topic --bootstrap-server kafka:9092 > /dev/null"
+      && kafka-console-consumer.sh --consumer-property group.id=test-consumer-group-two --consumer-property client.id=test-client-two-id-1 --consumer-property enable.auto.commit=true --topic replicated-topic --bootstrap-server kafka:9093 > /dev/null"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Version {
   val Akka = "2.6.20"
   val Prometheus = "0.15.0"
   val Fabric8 = "4.11.2"
-  val Kafka = "3.2.3"
+  val Kafka = "2.8.2"
   val Testcontainers = "1.17.5"
   val IAMAuth = "1.1.4"
   val Redis = "3.42"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,11 @@ object Dependencies {
   private val jacksonExclusionRule = ExclusionRule("com.fasterxml.jackson.core")
   private val log4jExclusionRule = ExclusionRule("log4j")
   private val slf4jExclusionRule = ExclusionRule("org.slf4j")
+  private val jacksonDataFormatCborExclusionRule =
+    ExclusionRule("com.fasterxml.jackson.dataformat", "jackson-dataformat-cbor")
+  private val snakeExclusionRule = ExclusionRule("org.yaml", "snakeyaml")
+  private val okHttpExclusionRule =
+    ExclusionRule("com.squareup.okhttp3", "okhttp3")
 
   val LightbendConfig = "com.typesafe" % "config" % "1.3.2"
   val Kafka =
@@ -41,13 +46,20 @@ object Dependencies {
     "io.prometheus" % "simpleclient_hotspot" % Version.Prometheus
   val PrometheusHttpServer =
     "io.prometheus" % "simpleclient_httpserver" % Version.Prometheus
-  val Fabric8Model = "io.fabric8" % "kubernetes-model" % Version.Fabric8
-  val Fabric8Client = "io.fabric8" % "kubernetes-client" % Version.Fabric8
+  val Fabric8Model =
+    "io.fabric8" % "kubernetes-model" % Version.Fabric8 excludeAll (snakeExclusionRule, okHttpExclusionRule)
+  val Fabric8Client =
+    "io.fabric8" % "kubernetes-client" % Version.Fabric8 excludeAll (snakeExclusionRule, okHttpExclusionRule)
   val ScalaJava8Compat =
     "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2"
   val AkkaHttp = "com.typesafe.akka" %% "akka-http" % "10.2.10"
-  val IAMAuthLib = "software.amazon.msk" % "aws-msk-iam-auth" % Version.IAMAuth
+  val IAMAuthLib =
+    "software.amazon.msk" % "aws-msk-iam-auth" % Version.IAMAuth excludeAll (jacksonDataFormatCborExclusionRule)
   val ScalaRedis = "net.debasishg" %% "redisclient" % Version.Redis
+  val JacksonDataFormat =
+    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.11.4"
+  val SnakeYaml = "org.yaml" % "snakeyaml" % "1.33"
+  val OkHttp = "com.squareup.okhttp3" % "okhttp" % "4.9.3"
 
   /* Test */
   val AkkaTypedTestKit =


### PR DESCRIPTION
The [FIND_COORDINATOR](https://kafka.apache.org/protocol.html#The_Messages_FindCoordinator) API is not compatible between kafka client 3.2.3 and broker version 2.8.2

```
Call(callName=describeGroups(api=FIND_COORDINATOR), deadlineMs=1668471194837, tries=1, nextAllowedTryMs=1668471185837) failed with non-retriable exception after 1 attempt(s) java.lang.Exception: NoBatchedFindCoordinatorsException: Cannot create a v3 FindCoordinator request because we require features supported only in 4 or later.
```

This also fixes a number of Snyk-identified CVEs.